### PR TITLE
Fix DateFormat for parsing EEE

### DIFF
--- a/lib/util/datetime.dart
+++ b/lib/util/datetime.dart
@@ -30,7 +30,8 @@ DateTime? _parseRfc822DateTime(String dateString) {
       pattern = rfc822DateWithoutSecondsPattern;
     }
 
-    final format = DateFormat(pattern);
+    //force locale to en_US because EEE always en_US and cannot be parsed in other locales
+    final format = DateFormat(pattern,'en_US');
     return format.parse(dateString, utc);
   } on FormatException {
     return null;


### PR DESCRIPTION
EEE in webfeeds always in en_US